### PR TITLE
chore: update company name references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017-present Sequence Platforms ULC Inc.
+   Copyright (c) 2017-present Sequence Platforms ULC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017-present Horizon Blockchain Games Inc.
+   Copyright (c) 2017-present Sequence Platforms ULC Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ In addition, it becomes easier to have multiple version of wrapper contracts. In
 # Security Review
 
 erc20-meta-token has been audited by two independant parties and all issues discovered were addressed. 
-- [Agustín Aguilar**](https://github.com/0xsequence/erc20-meta-token/blob/master/audits/Security_Audit_Horizon_Games_23-12-19_2.pdf)
+- [Agustín Aguilar**](https://github.com/0xsequence/erc20-meta-token/blob/master/audits/Security_Audit_Sequence_Games_23-12-19_2.pdf)
 - [Consensys Diligence](https://github.com/0xsequence/erc20-meta-token/blob/master/audits/horizon-games-audit-2020-02.pdf)
 
-** Agustín was hired as a full-time employee at Horizon after the audit was completed. Agustín did not take part in the writing of erc20-meta-token contracts.
+** Agustín was hired as a full-time employee at Sequence after the audit was completed. Agustín did not take part in the writing of erc20-meta-token contracts.
 
 ## Dev env & release
 
@@ -64,6 +64,6 @@ in their toolchains as our build and contract packages are separated.
 
 ## LICENSE
 
-Copyright (c) 2017-present [Horizon Blockchain Games Inc](https://horizon.io).
+Copyright (c) 2017-present [Sequence Platforms ULC Inc](https://horizon.io).
 
 Licensed under [Apache-2.0](./LICENSE)

--- a/src/README.md
+++ b/src/README.md
@@ -44,6 +44,6 @@ contract ContractA {
 
 ## LICENSE
 
-Copyright (c) 2017-present [Horizon Blockchain Games Inc](https://horizon.io).
+Copyright (c) 2017-present [Sequence Platforms ULC Inc](https://horizon.io).
 
 Licensed under [Apache-2.0](https://github.com/0xsequence/erc-1155/blob/master/LICENSE)


### PR DESCRIPTION
Automated cleanup of legacy company name references:

- "Horizon Blockchain Games" → "Sequence Platforms ULC"
- "Sequence Platforms Inc." → "Sequence Platforms ULC"
- "Horizon" → "Sequence"

Scope: README / LICENSE / package.json files (excluding vendor/).